### PR TITLE
Fix error when requesting files smaller than filesystem block size

### DIFF
--- a/uwsgi/spockfs.c
+++ b/uwsgi/spockfs.c
@@ -131,7 +131,7 @@ static int spockfs_get(struct wsgi_request *wsgi_req, char *path) {
 
 	size_t fsize = st.st_size;
 	// security check
-	if (wsgi_req->range_from > fsize) {
+	if (wsgi_req->range_from >= fsize) {
 		wsgi_req->range_from = 0;
 		wsgi_req->range_to = 0;
 	}
@@ -141,7 +141,7 @@ static int spockfs_get(struct wsgi_request *wsgi_req, char *path) {
 			fsize = st.st_size - wsgi_req->range_from;
 		}
 		if (uwsgi_response_prepare_headers(wsgi_req, "206 Partial Content", 19)) goto end;
-		if (uwsgi_response_add_content_range(wsgi_req, wsgi_req->range_from, wsgi_req->range_to, st.st_size)) goto end;
+		if (uwsgi_response_add_content_range(wsgi_req, wsgi_req->range_from, wsgi_req->range_from + fsize - 1, st.st_size)) goto end;
 	}
 	else {
 		if (uwsgi_response_prepare_headers(wsgi_req, "200 OK", 6)) goto end;


### PR DESCRIPTION
Hi,
I was very interested by this project but it wasn't working out of the box for me.

Firstly, here my system specs :
 - Debian 9 latest version with ext4 filesystem
 - Latest uwsgi server from pip in standalone mode
 - Freshly compiled spockfs client and server plugin.

The issue is crashes during testing script and I wasn't able to read any file. (everything else seems ok).
After few debugging, I noticed that FUSE on my system always requests at least one block size of data (in my case, 4096 bytes).
If the file (or a file part, like the last one E.g.) was smaller than 4096, the server side doesn't understand and causes errors.

I fixed this by relying always on server filesystem metadata instead of what is requested by the client. In the PR, tests are ok and file reading is now working for me.
