### PR TITLE
Adds gitignore; ignoring executable stuff (Mac) and a test mount point.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+spockfs
+spockfs.dSYM
+mnttest


### PR DESCRIPTION
Ignores spokes, .dSYM dir (Mac), and a test mount point at mnttest.